### PR TITLE
Use mpg123 module from runtime

### DIFF
--- a/audio-libs.json
+++ b/audio-libs.json
@@ -37,15 +37,6 @@
                 "type": "shell",
                 "commands": ["cp -p /usr/share/automake-*/config.{sub,guess} ."]
             }]
-        },
-        {
-            "name": "mpg123",
-            "buildsystem": "autotools",
-            "sources": [{
-               "type": "archive",
-                "url": "https://downloads.sourceforge.net/mpg123/mpg123-1.26.5.tar.bz2",
-                "sha256": "502a97e0d935be7e37d987338021d8f301bae35c2884f2a83d59c4b52466ef06"
-            }]
         }
     ]
 }


### PR DESCRIPTION
GNOME runtime version 48 (based on the Freedesktop runtime version 24.08) appears to provide the **mpg123** module.

**Related manifest file**

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/24.08/elements/components/mpg123.bst